### PR TITLE
GitHub ci improve

### DIFF
--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -47,13 +47,19 @@ jobs:
           path: ~/.cargo/bin/circom
           key: circom
 
+      - name: Get Circuit Hash
+        id: get-circuit-hash
+        run: |
+          echo "circuit_hash=`circom-rsa-verify && git rev-parse HEAD && cd ..`" >> $GITHUB_OUTPUT
+        shell: bash
+  
       - name: Cache proving/verify key 
         id: zkkeys 
         uses: actions/cache@v3
         with: 
           path: build/circuit
-          key: ${{ hashFiles('build/hash.txt') }}
-          
+          key: ${{  steps.get-circuit-hash.outputs.circuit_hash }}
+
       - name: Download power of tau and install Circom
         run: yarn dev-install
 

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -55,5 +55,5 @@ jobs:
 
       # - name: Build packages
       #   run: yarn build
-      # - name: Test packages
-      #   run: yarn test
+      - name: Test packages
+        run: yarn test

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -50,10 +50,10 @@ jobs:
       - name: Download power of tau and install Circom
         run: yarn dev-install
 
-      - name: 'Dev trusted setup'
-        run: 'yarn dev-setup'
+      # - name: 'Dev trusted setup'
+      #   run: 'yarn dev-setup'
 
-      - name: Build packages
-        run: yarn build
-      - name: Test packages
-        run: yarn test
+      # - name: Build packages
+      #   run: yarn build
+      # - name: Test packages
+      #   run: yarn test

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -21,17 +21,17 @@ jobs:
         with:
           node-version: '18'
           cache: 'yarn'
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Check Yarn version
         run: yarn --version
       - name: Check Node version
         run: node --version
       - name: Install dependencies
         run: yarn install
-
       - name: Execute lint
         run: yarn lint
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
       
       - name: Cache power of tau
         id: powersOfTau28_hez_final_20
@@ -39,7 +39,6 @@ jobs:
         with:
           path: build/powersOfTau28_hez_final_20.ptau
           key: powersOfTau28_hez_final_20.ptau
-
       - name: Cache Circom
         id: Circom
         uses: actions/cache@v3
@@ -55,7 +54,7 @@ jobs:
         run: |
           echo "circuit_hash=`cd circom-rsa-verify && git rev-parse HEAD && cd ..`" >> $GITHUB_OUTPUT
         shell: bash
-  
+          
       - name: Cache proving/verify key 
         id: zkkeys 
         uses: actions/cache@v3

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -40,6 +40,9 @@ jobs:
           path: build/powersOfTau28_hez_final_20.ptau
           key: powersOfTau28_hez_final_20.ptau
 
+      - name: Test 
+        run: echo `$HOME/.cargo/bin/circom`
+
       - name: Cache Circom
         id: Circom
         uses: actions/cache@v3

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       
       - name: Cache power of tau
-        id: powersOfTau28_hez_final_20.ptau
+        id: powersOfTau28_hez_final_20
         uses: actions/cache@v3
         with:
           path: build/powersOfTau28_hez_final_20.ptau

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -27,14 +27,32 @@ jobs:
         run: node --version
       - name: Install dependencies
         run: yarn install
+
       - name: Execute lint
         run: yarn lint
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+      
+      - name: Cache power of tau
+        id: powersOfTau28_hez_final_20.ptau
+        uses: actions/cache@v3
+        with:
+          path: build/powersOfTau28_hez_final_20.ptau
+          key: powersOfTau28_hez_final_20.ptau
+
+      - name: Cache Circom
+        id: Circom
+        uses: actions/cache@v3
+        with:
+          path: $HOME/.cargo/bin/circom
+          key: circom
+
       - name: Download power of tau and install Circom
         run: yarn dev-install
+
       - name: 'Dev trusted setup'
         run: 'yarn dev-setup'
+
       - name: Build packages
         run: yarn build
       - name: Test packages

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -40,6 +40,13 @@ jobs:
           path: build/powersOfTau28_hez_final_20.ptau
           key: powersOfTau28_hez_final_20.ptau
 
+      - name: Cache proving/verify key 
+        id: zkkeys 
+        uses: actions/cache
+        with: 
+          path: build/circuit
+          key: ${{ hashFiles('build/hash.txt') }}
+
       - name: Test 
         run: echo `~/.cargo/bin/circom`
 
@@ -53,10 +60,10 @@ jobs:
       - name: Download power of tau and install Circom
         run: yarn dev-install
 
-      # - name: 'Dev trusted setup'
-      #   run: 'yarn dev-setup'
+      - name: 'Dev trusted setup'
+        run: 'yarn dev-setup'
 
-      # - name: Build packages
-      #   run: yarn build
-      # - name: Test packages
-      #   run: yarn test
+      - name: Build packages
+        run: yarn build
+      - name: Test packages
+        run: yarn test

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -47,7 +47,7 @@ jobs:
         id: Circom
         uses: actions/cache@v3
         with:
-          path: ~/.cargo/bin
+          path: ~/.cargo/bin/circom
           key: circom
 
       - name: Download power of tau and install Circom

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -40,16 +40,6 @@ jobs:
           path: build/powersOfTau28_hez_final_20.ptau
           key: powersOfTau28_hez_final_20.ptau
 
-      - name: Cache proving/verify key 
-        id: zkkeys 
-        uses: actions/cache
-        with: 
-          path: build/circuit
-          key: ${{ hashFiles('build/hash.txt') }}
-
-      - name: Test 
-        run: echo `~/.cargo/bin/circom`
-
       - name: Cache Circom
         id: Circom
         uses: actions/cache@v3
@@ -57,6 +47,13 @@ jobs:
           path: ~/.cargo/bin/circom
           key: circom
 
+      - name: Cache proving/verify key 
+        id: zkkeys 
+        uses: actions/cache@v3
+        with: 
+          path: build/circuit
+          key: ${{ hashFiles('build/hash.txt') }}
+          
       - name: Download power of tau and install Circom
         run: yarn dev-install
 

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -47,7 +47,7 @@ jobs:
         id: Circom
         uses: actions/cache@v3
         with:
-          path: ~/.cargo/bin/circom
+          path: ~/.cargo/bin
           key: circom
 
       - name: Download power of tau and install Circom

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -47,6 +47,9 @@ jobs:
           path: ~/.cargo/bin/circom
           key: circom
 
+      - name: Download power of tau and install Circom
+        run: yarn dev-install
+
       - name: Get Circuit Hash
         id: get-circuit-hash
         run: |
@@ -58,10 +61,8 @@ jobs:
         uses: actions/cache@v3
         with: 
           path: build/circuit
-          key: ${{  steps.get-circuit-hash.outputs.circuit_hash }}
+          key: ${{ steps.get-circuit-hash.outputs.circuit_hash }}
 
-      - name: Download power of tau and install Circom
-        run: yarn dev-install
 
       - name: 'Dev trusted setup'
         run: 'yarn dev-setup'

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Get Circuit Hash
         id: get-circuit-hash
         run: |
-          echo "circuit_hash=`circom-rsa-verify && git rev-parse HEAD && cd ..`" >> $GITHUB_OUTPUT
+          echo "circuit_hash=`cd circom-rsa-verify && git rev-parse HEAD && cd ..`" >> $GITHUB_OUTPUT
         shell: bash
   
       - name: Cache proving/verify key 

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -58,5 +58,5 @@ jobs:
 
       # - name: Build packages
       #   run: yarn build
-      - name: Test packages
-        run: yarn test
+      # - name: Test packages
+      #   run: yarn test

--- a/.github/workflows/01-workflow.yaml
+++ b/.github/workflows/01-workflow.yaml
@@ -41,13 +41,13 @@ jobs:
           key: powersOfTau28_hez_final_20.ptau
 
       - name: Test 
-        run: echo `$HOME/.cargo/bin/circom`
+        run: echo `~/.cargo/bin/circom`
 
       - name: Cache Circom
         id: Circom
         uses: actions/cache@v3
         with:
-          path: $HOME/.cargo/bin/circom
+          path: ~/.cargo/bin/circom
           key: circom
 
       - name: Download power of tau and install Circom

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## About project
 
 ## Requirements 
-Install `rust` and `nodejs`, `openssl`(Usually installed in MacOs and Linux).
+Install `rust` and `nodejs v18`, `openssl`(Usually installed in macOS and Linux).
 
 ## Install and test
 

--- a/script/setup-dev.sh
+++ b/script/setup-dev.sh
@@ -45,20 +45,32 @@ function install_deps() {
 # DON'T USE IT IN PRODUCT
 function setup_circuit() {
     echo "TRUSTED SETUP FOR DEVELOPMENT - PLEASE, DON'T USE IT IN PRODUCT!!!!"
+    cd $BUILD_DIR 
+
+    if [ ! -f $POWERS_OF_TAU ]; then 
+        OLD_HASH=`cat hash.txt`
+        echo $OLD_HASH 
+    else 
+        OLD_HASH=""
+    fi
     
     cd $RSA_DIR
     yarn
     
     cd $RSA_DIR/circom-ecdsa
-    yarn
-    
+    yarn 
     echo "Starting setup...!"
     cd $RSA_DIR/test
-    circom circuits/rsa_verify_sha1_pkcs1v15.circom  --r1cs --wasm -o $BUILD_DIR
-    npx snarkjs groth16 setup $BUILD_DIR/rsa_verify_sha1_pkcs1v15.r1cs $POWERS_OF_TAU $BUILD_DIR/circuit_0000.zkey
-    echo "test random" | npx snarkjs zkey contribute $BUILD_DIR/circuit_0000.zkey $BUILD_DIR/circuit_final.zkey
-    npx snarkjs zkey export verificationkey $BUILD_DIR/circuit_final.zkey $BUILD_DIR/verification_key.json
-    
+    HASH=`git rev-parse HEAD`
+    CIRCUIT=circuit
+    if [ "$HASH" != "$OLD_HASH" ]; then 
+        mkdir -p $BUILD_DIR/$CIRCUIT
+        circom circuits/rsa_verify_sha1_pkcs1v15.circom  --r1cs --wasm -o $BUILD_DIR/$CIRCUIT
+        npx snarkjs groth16 setup $BUILD_DIR/$CIRCUIT/rsa_verify_sha1_pkcs1v15.r1cs $POWERS_OF_TAU $BUILD_DIR/$CIRCUIT/circuit_0000.zkey
+        echo "test random" | npx snarkjs zkey contribute $BUILD_DIR/$CIRCUIT/circuit_0000.zkey $BUILD_DIR/$CIRCUIT/circuit_final.zkey
+        npx snarkjs zkey export verificationkey $BUILD_DIR/$CIRCUIT/circuit_final.zkey $BUILD_DIR/$CIRCUIT/verification_key.json
+    fi 
+
     echo "Finish setup....!"
 
     echo "Copy proving key and verify key to artifacts!!!!"
@@ -69,9 +81,10 @@ function setup_circuit() {
         mkdir -p $ARTIFACTS_DIR
     fi
 
-    cp rsa_verify_sha1_pkcs1v15_js/rsa_verify_sha1_pkcs1v15.wasm $ARTIFACTS_DIR
-    cp circuit_final.zkey $ARTIFACTS_DIR
-    cp verification_key.json $ARTIFACTS_DIR
+    cp $CIRCUIT/rsa_verify_sha1_pkcs1v15_js/rsa_verify_sha1_pkcs1v15.wasm $ARTIFACTS_DIR
+    cp $CIRCUIT/circuit_final.zkey $ARTIFACTS_DIR
+    cp $CIRCUIT/verification_key.json $ARTIFACTS_DIR
+    echo $HASH > hash.txt
     echo "Setup finished!"
 }
 

--- a/script/setup-dev.sh
+++ b/script/setup-dev.sh
@@ -52,8 +52,9 @@ function setup_circuit() {
     echo "TRUSTED SETUP FOR DEVELOPMENT - PLEASE, DON'T USE IT IN PRODUCT!!!!"
     cd $BUILD_DIR 
 
-    if [ -f hash.txt ]; then 
-        OLD_HASH=`cat hash.txt`
+    CIRCUIT=circuit
+    if [ -f $CIRCUIT/hash.txt ]; then 
+        OLD_HASH=`cat $CIRCUIT/hash.txt`
         echo $OLD_HASH 
     else 
         OLD_HASH=""
@@ -67,7 +68,6 @@ function setup_circuit() {
     echo "Starting setup...!"
     cd $RSA_DIR/test
     HASH=`git rev-parse HEAD`
-    CIRCUIT=circuit
     if [ "$HASH" != "$OLD_HASH" ]; then 
         mkdir -p $BUILD_DIR/$CIRCUIT
         circom circuits/rsa_verify_sha1_pkcs1v15.circom  --r1cs --wasm -o $BUILD_DIR/$CIRCUIT
@@ -89,7 +89,7 @@ function setup_circuit() {
     cp $CIRCUIT/rsa_verify_sha1_pkcs1v15_js/rsa_verify_sha1_pkcs1v15.wasm $ARTIFACTS_DIR
     cp $CIRCUIT/circuit_final.zkey $ARTIFACTS_DIR
     cp $CIRCUIT/verification_key.json $ARTIFACTS_DIR
-    echo $HASH > hash.txt
+    echo $HASH > $CIRCUIT/hash.txt
     echo "Setup finished!"
 }
 

--- a/script/setup-dev.sh
+++ b/script/setup-dev.sh
@@ -52,7 +52,7 @@ function setup_circuit() {
     echo "TRUSTED SETUP FOR DEVELOPMENT - PLEASE, DON'T USE IT IN PRODUCT!!!!"
     cd $BUILD_DIR 
 
-    if [ ! -f $POWERS_OF_TAU ]; then 
+    if [ -f hash.txt ]; then 
         OLD_HASH=`cat hash.txt`
         echo $OLD_HASH 
     else 


### PR DESCRIPTION
Resolve #22.
Speed up a Github CI by cached.  We run CI test in 2 mins, very fast when compare with 30 mins in old implementation.
