### PR TITLE
fix: testing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.11
+
+- Add staging mode, where user can choose to generate proof with the official modulus.
+- Fix react Error toaster component.
+
 ## 0.1.10
 
 - Fix bug in react lib

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-identity-packages",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A set of tools to anonymously prove your identity",
   "main": "index.js",
   "private": true,

--- a/packages/anon-aadhaar-contracts/package.json
+++ b/packages/anon-aadhaar-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-contracts",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Verifier smart contract for the anon aadhaar circuit",
   "license": "MIT",
   "scripts": {

--- a/packages/anon-aadhaar-pcd/package.json
+++ b/packages/anon-aadhaar-pcd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-pcd",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "./dist/index.js",
   "types": "./src/index.ts",
   "repository": "https://github.com/privacy-scaling-explorations/anon-aadhaar",

--- a/packages/anon-aadhaar-pcd/src/pcd.ts
+++ b/packages/anon-aadhaar-pcd/src/pcd.ts
@@ -47,7 +47,7 @@ export async function prove(args: AnonAadhaarPCDArgs): Promise<AnonAadhaarPCD> {
   }
 
   if (!args.modulus.value) {
-    throw new Error('Invalid arguments')
+    throw new Error('Invalid modulus argument')
   }
 
   const id = uuidv4()

--- a/packages/anon-aadhaar-react/package.json
+++ b/packages/anon-aadhaar-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-react",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Frontend component kit for the country identity pcd package",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/anon-aadhaar-react/src/components/LogInWithAnonAadhaar.tsx
+++ b/packages/anon-aadhaar-react/src/components/LogInWithAnonAadhaar.tsx
@@ -16,6 +16,7 @@ import { AnonAadhaarContext } from '../hooks/useAnonAadhaar'
  */
 export const LogInWithAnonAadhaar = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const { state, startReq } = useContext(AnonAadhaarContext)
 
   useEffect(() => {
@@ -28,6 +29,7 @@ export const LogInWithAnonAadhaar = () => {
 
   const closeModal = () => {
     setIsModalOpen(false)
+    setErrorMessage(null)
   }
 
   return (
@@ -37,7 +39,12 @@ export const LogInWithAnonAadhaar = () => {
           <Btn onClick={openModal}>
             {text('🌏', 'Log In with Anon Aadhaar')}
           </Btn>
-          <ProveModal isOpen={isModalOpen} onClose={closeModal}></ProveModal>
+          <ProveModal
+            isOpen={isModalOpen}
+            onClose={closeModal}
+            errorMessage={errorMessage}
+            setErrorMessage={setErrorMessage}
+          ></ProveModal>
         </div>
       )}
       {state.status === 'logged-in' && (

--- a/packages/anon-aadhaar-react/src/components/ProveButton.tsx
+++ b/packages/anon-aadhaar-react/src/components/ProveButton.tsx
@@ -1,7 +1,7 @@
 import { AnonAadhaarPCDArgs } from 'anon-aadhaar-pcd'
 import { ArgumentTypeName } from '@pcd/pcd-types'
 import styled from 'styled-components'
-import { Dispatch, useContext, SetStateAction, useEffect } from 'react'
+import { Dispatch, useContext, SetStateAction } from 'react'
 import { AnonAadhaarContext } from '../hooks/useAnonAadhaar'
 import { Spinner } from './LoadingSpinner'
 import React from 'react'
@@ -22,8 +22,6 @@ export const ProveButton: React.FC<ProveButtonProps> = ({
   setErrorMessage,
 }) => {
   const { state, startReq, appId, testing } = useContext(AnonAadhaarContext)
-
-  useEffect(() => console.log('Testing :', testing), [testing])
 
   const startProving = async () => {
     try {

--- a/packages/anon-aadhaar-react/src/components/ProveButton.tsx
+++ b/packages/anon-aadhaar-react/src/components/ProveButton.tsx
@@ -31,69 +31,44 @@ export const ProveButton: React.FC<ProveButtonProps> = ({
 
       if (witness instanceof Error) throw new Error(witness.message)
 
-      let args: AnonAadhaarPCDArgs
+      let publicKey = ''
 
-      if (testing === false) {
-        const publicKey = await fetchPublicKey(
+      if (!testing) {
+        const result = await fetchPublicKey(
           'https://www.uidai.gov.in/images/authDoc/uidai_offline_publickey_26022021.cer',
         )
-
-        if (publicKey === null)
+        if (result === null) {
           throw new Error('Error while fetching the public key!')
+        } else {
+          publicKey = result
+        }
+      }
 
-        args = {
-          base_message: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: witness?.msgBigInt.toString(),
-            description: '',
-          },
-          signature: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: witness?.sigBigInt.toString(),
-            description: '',
-          },
-          modulus: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: '0x' + publicKey,
-            description: '',
-          },
-          app_id: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: appId,
-            description: '',
-          },
-        }
-      } else {
-        args = {
-          base_message: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: witness?.msgBigInt.toString(),
-            description: '',
-          },
-          signature: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: witness?.sigBigInt.toString(),
-            description: '',
-          },
-          modulus: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: witness?.modulusBigInt.toString(),
-            description: '',
-          },
-          app_id: {
-            argumentType: ArgumentTypeName.BigInt,
-            userProvided: false,
-            value: appId,
-            description: '',
-          },
-        }
+      const args: AnonAadhaarPCDArgs = {
+        base_message: {
+          argumentType: ArgumentTypeName.BigInt,
+          userProvided: false,
+          value: witness?.msgBigInt.toString(),
+          description: '',
+        },
+        signature: {
+          argumentType: ArgumentTypeName.BigInt,
+          userProvided: false,
+          value: witness?.sigBigInt.toString(),
+          description: '',
+        },
+        modulus: {
+          argumentType: ArgumentTypeName.BigInt,
+          userProvided: false,
+          value: testing ? witness.modulusBigInt.toString() : '0x' + publicKey,
+          description: '',
+        },
+        app_id: {
+          argumentType: ArgumentTypeName.BigInt,
+          userProvided: false,
+          value: appId,
+          description: '',
+        },
       }
 
       startReq({ type: 'login', args })

--- a/packages/anon-aadhaar-react/src/components/ProveModal.tsx
+++ b/packages/anon-aadhaar-react/src/components/ProveModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, Dispatch, SetStateAction } from 'react'
 import styled from 'styled-components'
 import { FileInput } from './FileInput'
 import { ProveButton } from './ProveButton'
@@ -10,14 +10,20 @@ import { ErrorToast } from './ErrorToast'
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
+  errorMessage: string | null
+  setErrorMessage: Dispatch<SetStateAction<string | null>>
 }
 
-export const ProveModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+export const ProveModal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  errorMessage,
+  setErrorMessage,
+}) => {
   const [pdfData, setPdfData] = useState(Buffer.from([]))
   const [password, setPassword] = useState<string>('')
   const [pdfStatus, setpdfStatus] = useState<'' | AadhaarPdfValidation>('')
   const [provingEnabled, setProvingEnabled] = useState<boolean>(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const handlePdfChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const { pdf } = await uploadPdf(e, setpdfStatus)

--- a/packages/anon-aadhaar-react/src/hooks/useAnonAadhaar.ts
+++ b/packages/anon-aadhaar-react/src/hooks/useAnonAadhaar.ts
@@ -26,12 +26,14 @@ export const AnonAadhaarContext = createContext<AnonAadhaarContextVal>({
     // StartReq
   },
   appId: '',
+  testing: true,
 })
 
 export interface AnonAadhaarContextVal {
   state: AnonAadhaarState
   startReq: (request: AnonAadhaarRequest) => void
   appId: string | null
+  testing: boolean
 }
 
 export type AnonAadhaarRequest =

--- a/packages/anon-aadhaar-react/src/provider/AnonAadhaarProvider.tsx
+++ b/packages/anon-aadhaar-react/src/provider/AnonAadhaarProvider.tsx
@@ -25,6 +25,7 @@ import { SerializedPCD } from '@pcd/pcd-types'
 export function AnonAadhaarProvider(props: {
   children: ReactNode
   _appId: string
+  _testing?: boolean
 }) {
   // Read state from local storage on page load
   const [pcdStr, setPcdStr] = useState<SerializedPCD<AnonAadhaarPCD> | null>(
@@ -32,6 +33,7 @@ export function AnonAadhaarProvider(props: {
   )
   const [pcd, setPcd] = useState<AnonAadhaarPCD | null>(null)
   const [appId, setAppId] = useState<string | null>(null)
+  const [testing, setTesting] = useState<boolean>(true)
   const [state, setState] = useState<AnonAadhaarState>({
     status: 'logged-out',
   })
@@ -40,6 +42,7 @@ export function AnonAadhaarProvider(props: {
       console.warn('[ANON-AADHAAR]: Please provide a valid appId')
     readFromLocalStorage().then(setAndWriteState)
     setAppId(props._appId)
+    if (props._testing !== undefined) setTesting(props._testing)
   }, [props._appId])
 
   // Write state to local storage whenever a login starts, succeeds, or fails
@@ -78,7 +81,10 @@ export function AnonAadhaarProvider(props: {
   }, [pcdStr])
 
   // Provide context
-  const val = React.useMemo(() => ({ state, startReq, appId }), [state, appId])
+  const val = React.useMemo(
+    () => ({ state, startReq, appId, testing }),
+    [state, appId, testing],
+  )
 
   return (
     <AnonAadhaarContext.Provider value={val}>

--- a/packages/anon-aadhaar-react/src/util.ts
+++ b/packages/anon-aadhaar-react/src/util.ts
@@ -98,3 +98,27 @@ export const uploadPdf = (
     }
   })
 }
+
+/**
+ * Fetch the public key PEM file from the serverless function endpoint.
+ * @param url Endpoint URL to fetch the public key.
+ * @returns {Promise<string | null>} The official Aadhaar public key.
+ */
+export const fetchPublicKey = async (
+  certUrl: string,
+): Promise<string | null> => {
+  try {
+    const response = await fetch(
+      `https://nodejs-serverless-function-express-eight-iota.vercel.app/api/get-public-key?url=${certUrl}`,
+    )
+    if (!response.ok) {
+      throw new Error(`Failed to fetch public key from server`)
+    }
+
+    const publicKeyData = await response.json()
+    return publicKeyData.publicKey || null
+  } catch (error) {
+    console.error('Error fetching public key:', error)
+    return null
+  }
+}

--- a/packages/anon-aadhaar-react/test/hook.test.tsx
+++ b/packages/anon-aadhaar-react/test/hook.test.tsx
@@ -26,6 +26,7 @@ describe('useCountryIdentity Hook', () => {
           state: initialState,
           startReq: startReqFunction,
           appId: BigInt(1234555).toString(),
+          testing: true,
         }}
       >
         {children}


### PR DESCRIPTION
## Motivation

It enables the user to set the testing mode to false and generates proof with the official modulus.
I have to spin up a server fetching the .cer file directly from the official website. 

## Change Summary

- New `fetchPublicKey()` component that queries a backend endpoint and returns the public key in bigint format.
- Added testing variable to Context Provider
- Fix error toaster issue

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/privacy-scaling-explorations/anon-aadhaar/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.