### PR TITLE
fix: localhost mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.14
+
+- Added localhost mode, to fetch artifacts from local.
+
 ## 0.1.13
 
 - Fix scripts for npm CI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-identity-packages",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A set of tools to anonymously prove your identity",
   "main": "index.js",
   "private": true,

--- a/packages/anon-aadhaar-contracts/package.json
+++ b/packages/anon-aadhaar-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-contracts",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Verifier smart contract for the anon aadhaar circuit",
   "license": "MIT",
   "scripts": {

--- a/packages/anon-aadhaar-pcd/package.json
+++ b/packages/anon-aadhaar-pcd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-pcd",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "./dist/index.js",
   "types": "./src/index.ts",
   "repository": "https://github.com/privacy-scaling-explorations/anon-aadhaar",

--- a/packages/anon-aadhaar-pcd/src/pcd.ts
+++ b/packages/anon-aadhaar-pcd/src/pcd.ts
@@ -69,23 +69,19 @@ export async function prove(args: AnonAadhaarPCDArgs): Promise<AnonAadhaarPCD> {
 }
 
 async function getVerifyKey() {
-  let vk
   if (!initArgs) {
     throw new Error(
       'cannot make Anon Aadhaar proof: init has not been called yet'
     )
   }
-  if (initArgs.isWebEnv) {
-    const response = await fetch(initArgs.vkeyURL)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch the verify key from server`)
-    }
 
-    vk = await response.json()
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    vk = require(initArgs.vkeyURL)
+  const response = await fetch(initArgs.vkeyURL)
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch the verify key from server`)
   }
+
+  const vk = await response.json()
   return vk
 }
 

--- a/packages/anon-aadhaar-react/package.json
+++ b/packages/anon-aadhaar-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-react",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Frontend component kit for the country identity pcd package",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/anon-aadhaar-react/src/components/ProveModal.tsx
+++ b/packages/anon-aadhaar-react/src/components/ProveModal.tsx
@@ -122,7 +122,7 @@ const ModalContent = styled.div`
   @media (max-width: 425px) {
     /* For screens <= 425px (e.g., mobile devices) */
     width: 100%;
-    height: 55%;
+    height: 67%;
     max-width: 100%;
     max-height: 100%;
   }

--- a/packages/anon-aadhaar-react/src/prove.ts
+++ b/packages/anon-aadhaar-react/src/prove.ts
@@ -22,7 +22,7 @@ import {
  * @see {@link https://github.com/privacy-scaling-explorations/anon-aadhaar}
  *   For more information about the underlying circuit and proving system.
  */
-export const proveAndVerify = async (
+export const proveAndSerialize = async (
   pcdArgs: AnonAadhaarPCDArgs,
   isWeb: boolean,
 ): Promise<{

--- a/packages/anon-aadhaar-react/src/prove.ts
+++ b/packages/anon-aadhaar-react/src/prove.ts
@@ -22,17 +22,18 @@ import {
  * @see {@link https://github.com/privacy-scaling-explorations/anon-aadhaar}
  *   For more information about the underlying circuit and proving system.
  */
-export const proveWithWebProver = async (
+export const proveAndVerify = async (
   pcdArgs: AnonAadhaarPCDArgs,
+  isWeb: boolean,
 ): Promise<{
   pcd: AnonAadhaarPCD
   serialized: SerializedPCD<AnonAadhaarPCD>
 }> => {
   const pcdInitArgs: PCDInitArgs = {
-    wasmURL: WASM_URL,
-    zkeyURL: ZKEY_URL,
-    vkeyURL: VK_URL,
-    isWebEnv: true,
+    wasmURL: isWeb ? WASM_URL : '/main.wasm',
+    zkeyURL: isWeb ? ZKEY_URL : '/circuit_final.zkey',
+    vkeyURL: isWeb ? VK_URL : '/verification_key.json',
+    isWebEnv: isWeb,
   }
 
   await init(pcdInitArgs)

--- a/packages/anon-aadhaar-react/test/pcd.test.ts
+++ b/packages/anon-aadhaar-react/test/pcd.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'mocha'
 import { AnonAadhaarPCDArgs, verify, genData } from 'anon-aadhaar-pcd'
 import { assert } from 'chai'
 import { ArgumentTypeName } from '@pcd/pcd-types'
-import { proveAndVerify } from '../src/prove'
+import { proveAndSerialize } from '../src/prove'
 
 describe('PCD tests', function () {
   this.timeout(0)
@@ -33,7 +33,7 @@ describe('PCD tests', function () {
       },
     }
 
-    const result = await proveAndVerify(pcdArgs, true)
+    const result = await proveAndSerialize(pcdArgs, true)
 
     const verified = await verify(result.pcd)
     assert(verified == true, 'Should verifiable')

--- a/packages/anon-aadhaar-react/test/pcd.test.ts
+++ b/packages/anon-aadhaar-react/test/pcd.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'mocha'
 import { AnonAadhaarPCDArgs, verify, genData } from 'anon-aadhaar-pcd'
 import { assert } from 'chai'
 import { ArgumentTypeName } from '@pcd/pcd-types'
-import { proveWithWebProver } from '../src/prove'
+import { proveAndVerify } from '../src/prove'
 
 describe('PCD tests', function () {
   this.timeout(0)
@@ -33,7 +33,7 @@ describe('PCD tests', function () {
       },
     }
 
-    const result = await proveWithWebProver(pcdArgs)
+    const result = await proveAndVerify(pcdArgs, true)
 
     const verified = await verify(result.pcd)
     assert(verified == true, 'Should verifiable')


### PR DESCRIPTION
## Motivation

In the context of the EthIndia hackathon, this mode enables builders to store snarkjs artifacts locally and run the proving flow on localhost without downloading them each time.

## Change Summary

- Add _isWeb context variable in the Provider.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/privacy-scaling-explorations/anon-aadhaar/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.