### PR TITLE
fix(chore): remove subtle from src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.15
+
+- Fix subtle dependency issue
+
 ## 0.1.14
 
 - Added localhost mode, to fetch artifacts from local.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-identity-packages",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A set of tools to anonymously prove your identity",
   "main": "index.js",
   "private": true,

--- a/packages/anon-aadhaar-contracts/package.json
+++ b/packages/anon-aadhaar-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-contracts",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Verifier smart contract for the anon aadhaar circuit",
   "license": "MIT",
   "scripts": {

--- a/packages/anon-aadhaar-contracts/test/Verifier.ts
+++ b/packages/anon-aadhaar-contracts/test/Verifier.ts
@@ -2,7 +2,6 @@ import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import {
-  genData,
   splitToWords,
   exportCallDataGroth16,
   extractWitness,
@@ -11,6 +10,7 @@ import {
 } from 'anon-aadhaar-pcd'
 import crypto from 'crypto'
 import { fetchKey } from './util'
+import { genData } from '../../anon-aadhaar-pcd/test/utils'
 import fs from 'fs'
 
 describe('VerifyProof', function () {

--- a/packages/anon-aadhaar-pcd/package.json
+++ b/packages/anon-aadhaar-pcd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-pcd",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "./dist/index.js",
   "types": "./src/index.ts",
   "repository": "https://github.com/privacy-scaling-explorations/anon-aadhaar",

--- a/packages/anon-aadhaar-pcd/script/generateInput.ts
+++ b/packages/anon-aadhaar-pcd/script/generateInput.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'fs'
-import { genData, splitToWords } from '../src'
+import { genData } from '../test/utils'
+import { splitToWords } from '../src'
 import crypto from 'crypto'
 
 const main = () => {

--- a/packages/anon-aadhaar-pcd/src/utils.ts
+++ b/packages/anon-aadhaar-pcd/src/utils.ts
@@ -1,7 +1,6 @@
 import { decryptPDF } from 'spdf'
 import { Proof } from './types'
 import { groth16, Groth16Proof, ZKArtifact } from 'snarkjs'
-import { subtle } from 'crypto'
 import * as x509 from '@peculiar/x509'
 import { BigNumberish } from './types'
 import { AnonAadhaarPCD } from './pcd'
@@ -109,54 +108,6 @@ export function packProof(originalProof: Groth16Proof): Proof {
     originalProof.pi_c[0],
     originalProof.pi_c[1],
   ]
-}
-
-function buffToBigInt(buff: string): bigint {
-  return BigInt('0x' + Buffer.from(buff, 'base64url').toString('hex'))
-}
-
-async function generateRsaKey(hash = 'SHA-256') {
-  const publicExponent = new Uint8Array([1, 0, 1])
-  const modulusLength = 2048
-  const { publicKey, privateKey } = await subtle.generateKey(
-    {
-      name: 'RSASSA-PKCS1-v1_5',
-      modulusLength,
-      publicExponent,
-      hash,
-    },
-    true,
-    ['sign', 'verify']
-  )
-
-  return { publicKey, privateKey }
-}
-
-export async function genData(
-  data: string,
-  HASH_ALGO: string
-): Promise<[bigint, bigint, bigint, bigint]> {
-  const keys = await generateRsaKey(HASH_ALGO)
-
-  const public_key = await subtle.exportKey('jwk', keys.publicKey)
-
-  const enc = new TextEncoder()
-  const text = enc.encode(data)
-  const hash = BigInt(
-    '0x' + Buffer.from(await subtle.digest(HASH_ALGO, text)).toString('hex')
-  )
-
-  const sign_buff = await subtle.sign(
-    { name: 'RSASSA-PKCS1-v1_5', hash: HASH_ALGO },
-    keys.privateKey,
-    text
-  )
-
-  const e = buffToBigInt(public_key.e as string)
-  const n = buffToBigInt(public_key.n as string)
-  const sign = BigInt('0x' + Buffer.from(sign_buff).toString('hex'))
-
-  return [e, sign, n, hash]
 }
 
 export const extractDecryptedCert = (

--- a/packages/anon-aadhaar-pcd/test/nullifier.test.ts
+++ b/packages/anon-aadhaar-pcd/test/nullifier.test.ts
@@ -1,5 +1,6 @@
 import { describe } from 'mocha'
-import { genData, splitToWords } from '../src/utils'
+import { splitToWords } from '../src/utils'
+import { genData } from './utils'
 import path from 'path'
 import { buildPoseidon } from 'circomlibjs'
 import crypto from 'crypto'

--- a/packages/anon-aadhaar-pcd/test/pcd.test.ts
+++ b/packages/anon-aadhaar-pcd/test/pcd.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'mocha'
 import { AnonAadhaarPCDArgs, PCDInitArgs } from '../src/types'
 import { init, prove, verify } from '../src/pcd'
 import { assert } from 'chai'
-import { genData } from '../src/utils'
+import { genData } from './utils'
 import { ArgumentTypeName } from '@pcd/pcd-types'
 import { WASM_URL, ZKEY_URL, VK_URL } from '../src/constants'
 

--- a/packages/anon-aadhaar-pcd/test/utils.ts
+++ b/packages/anon-aadhaar-pcd/test/utils.ts
@@ -1,0 +1,49 @@
+import { subtle } from 'crypto'
+
+async function generateRsaKey(hash = 'SHA-256') {
+  const publicExponent = new Uint8Array([1, 0, 1])
+  const modulusLength = 2048
+  const { publicKey, privateKey } = await subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength,
+      publicExponent,
+      hash,
+    },
+    true,
+    ['sign', 'verify']
+  )
+
+  return { publicKey, privateKey }
+}
+
+function buffToBigInt(buff: string): bigint {
+  return BigInt('0x' + Buffer.from(buff, 'base64url').toString('hex'))
+}
+
+export async function genData(
+  data: string,
+  HASH_ALGO: string
+): Promise<[bigint, bigint, bigint, bigint]> {
+  const keys = await generateRsaKey(HASH_ALGO)
+
+  const public_key = await subtle.exportKey('jwk', keys.publicKey)
+
+  const enc = new TextEncoder()
+  const text = enc.encode(data)
+  const hash = BigInt(
+    '0x' + Buffer.from(await subtle.digest(HASH_ALGO, text)).toString('hex')
+  )
+
+  const sign_buff = await subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5', hash: HASH_ALGO },
+    keys.privateKey,
+    text
+  )
+
+  const e = buffToBigInt(public_key.e as string)
+  const n = buffToBigInt(public_key.n as string)
+  const sign = BigInt('0x' + Buffer.from(sign_buff).toString('hex'))
+
+  return [e, sign, n, hash]
+}

--- a/packages/anon-aadhaar-react/package.json
+++ b/packages/anon-aadhaar-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anon-aadhaar-react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Frontend component kit for the country identity pcd package",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/anon-aadhaar-react/test/hook.test.tsx
+++ b/packages/anon-aadhaar-react/test/hook.test.tsx
@@ -7,9 +7,10 @@ import {
   AnonAadhaarContext,
   AnonAadhaarState,
 } from '../src/hooks/useAnonAadhaar'
-import { AnonAadhaarPCDArgs, genData } from 'anon-aadhaar-pcd'
+import { AnonAadhaarPCDArgs } from 'anon-aadhaar-pcd'
 import { ArgumentTypeName } from '@pcd/pcd-types'
 import { AnonAadhaarProvider } from '../src/provider/AnonAadhaarProvider'
+import { genData } from '../../anon-aadhaar-pcd/test/utils'
 
 describe('useCountryIdentity Hook', () => {
   let testData: [bigint, bigint, bigint, bigint]

--- a/packages/anon-aadhaar-react/test/pcd.test.ts
+++ b/packages/anon-aadhaar-react/test/pcd.test.ts
@@ -1,8 +1,9 @@
 import { describe } from 'mocha'
-import { AnonAadhaarPCDArgs, verify, genData } from 'anon-aadhaar-pcd'
+import { AnonAadhaarPCDArgs, verify } from 'anon-aadhaar-pcd'
 import { assert } from 'chai'
 import { ArgumentTypeName } from '@pcd/pcd-types'
 import { proveAndSerialize } from '../src/prove'
+import { genData } from '../../anon-aadhaar-pcd/test/utils'
 
 describe('PCD tests', function () {
   this.timeout(0)


### PR DESCRIPTION
## Motivation

This PR remove subtle crypto from the src directory.
Having it exported form src causes issue when building the SDK for browser env.

## Change Summary

- Put genData and GenRSA under the test folder.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [change set](https://github.com/privacy-scaling-explorations/anon-aadhaar/CHANGELOG.md)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bug fix, or chore)
- [x] PR includes documentation if necessary.